### PR TITLE
fix: do not unfold theorems given as explicit premises

### DIFF
--- a/Lean/Egg/Tests/Basic.lean
+++ b/Lean/Egg/Tests/Basic.lean
@@ -14,10 +14,7 @@ error: expected goal to be of type '=', '↔', '∀ ..., _ = _', or '∀ ..., _ 
 example : True := by
   egg
 
-/-- error: egg requires arguments to be theorems, definitions or axioms -/
-#guard_msgs in
-example : true = true := by
-  egg [true]
+def foo := true
 
 example : 0 = 0 := by
   egg

--- a/Lean/Egg/Tests/Calcify.lean
+++ b/Lean/Egg/Tests/Calcify.lean
@@ -24,7 +24,7 @@ variable (f : Nat → Nat → Nat)
 /--
 info: Try this: calc
     f 1 2
-    _ = f 2 1 := Eq.symm (h 2 1)
+    _ = f 2 1 := (h 2 1).symm
 -/
 #guard_msgs in
 example (h : ∀ x y : Nat, f x y = f y x) : f 1 2 = f 2 1 := by

--- a/Lean/Egg/Tests/Constants.lean
+++ b/Lean/Egg/Tests/Constants.lean
@@ -5,11 +5,6 @@ axiom ax : 1 = 2
 example : 1 = 2 := by
   egg [ax]
 
-/-- error: egg requires arguments to be theorems, definitions or axioms -/
-#guard_msgs in
-example : 0 = 0 := by
-  egg [Nat]
-
 opaque op : Nat
 
 /--

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "nomeata",
-   "rev": "67b07fc2ec499e6e029b5e6b301269ca0f36fce4",
+   "rev": "dbc14d28fad2b090158ad60e490da9067b4519be",
    "name": "calcify",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "nomeata",
-   "rev": "6e870afb3a470b113b11b6809ba5ce45aee1dfd1",
+   "rev": "67b07fc2ec499e6e029b5e6b301269ca0f36fce4",
    "name": "calcify",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",


### PR DESCRIPTION
and while I am at it:

* bump `calcify` for a bit improved simplification.
* use `realizeGlobalConstNoOverloadWithInfo`, as one should here (makes
  the names hoverable and work with lazily generated functions like `foo.eq_1`)
