### PR TITLE
Adds rewrites for structure projections

### DIFF
--- a/Lean/Egg/Core/Config.lean
+++ b/Lean/Egg/Core/Config.lean
@@ -37,6 +37,7 @@ structure Gen where
   explosion       := false
   derivedGuides   := true
   genGroundEqs    := true
+  genStructProj   := true
   deriving BEq
 
 structure DefEq extends Erasure where
@@ -45,6 +46,7 @@ structure DefEq extends Erasure where
   etaExpand := false
   beta      := true
   levels    := true
+  structProj:= true
 
 structure Backend where
   blockInvalidMatches := true

--- a/Lean/Egg/Core/Gen/StructureProjs.lean
+++ b/Lean/Egg/Core/Gen/StructureProjs.lean
@@ -127,3 +127,35 @@ theorem foo : (1,2).snd = 1 + 1 := rfl
   let constinfo ← getConstInfo `foo
   let names ← getStructureNames constinfo.value!
   logInfo s!"Structure names of {constinfo.value!}: {names}"
+
+set_option pp.raw true in
+#reduce (1,2)
+
+def pair : Prod Nat Nat := (1,2)
+
+instance : ToString ConstantInfo := ⟨fun cinfo => match cinfo with
+ | .axiomInfo  val => "Axiom: {val}"
+ | .defnInfo   val => "Defn: {val}"
+ | .thmInfo    val => "Thm: {val}"
+ | .opaqueInfo val => "Opaque: {val}"
+ | .quotInfo   val => "Quot: {val}"
+ | .inductInfo val => "Induct: {val}"
+ | .ctorInfo   val => "Ctor: {val}"
+ | .recInfo    val => "Rec: {val}"
+ ⟩
+
+#eval show MetaM Unit from do
+  let constinfo ← getConstInfo `pair
+  match constinfo.value! with
+    | Expr.app (Expr.app (Expr.app (Expr.app fn arg₁) arg₂) arg₃) arg₄ => do
+       logInfo s!"Function: {fn}"
+       logInfo s!"Arg: {arg₁}"
+       logInfo s!"Arg: {arg₂}"
+       logInfo s!"Arg: {arg₃}"
+       logInfo s!"Arg: {arg₄}"
+       let some (nm, _) := fn.const?
+         | throwError "Expected constant"
+       let constInfo ← getConstInfo nm
+       logInfo s!"Constant info: {constInfo}"
+       logInfo s!"structureFromConstantInfo {← getStructureFromConstantInfo constInfo}"
+    | _ => pure ()

--- a/Lean/Egg/Core/Gen/StructureProjs.lean
+++ b/Lean/Egg/Core/Gen/StructureProjs.lean
@@ -35,3 +35,86 @@ private def buildStructureProjEqns (structName : Name) (cfg : Rewrite.Config) : 
     let rw ← Rewrite.mkDefEq lhs rhs cfg
     rws := rw :: rws
   return rws.toArray
+
+/--
+For the given rewrite (`target`), we iterate over all subterms and collect
+ `structure`s that occur in them.
+
+We use a list since we later want to `eraseDups`, but this function
+does not exist for `Array`.
+-/
+private def getStructuresInRewrite (target : Rewrite)
+   : MetaM (List Name) := do
+   for c in target.conds do
+     for ..
+  return []
+
+/--
+To generate the structure projections, we first collect all the
+structures that occur in the rewrites. For each structure, we
+generate all the projections.
+-/
+def genStructureProjections (targets : Rewrites) (norm : Config.Normalization) (cfg : Config.Erasure) :
+    MetaM Rewrites := do
+      let structures ← targets.foldlM (init := []) fun rws rw => do
+        return rws ++ (← getStructuresInRewrite rw)
+      -- deduplicate names, convert to array
+      structures.eraseDups
+       |>.foldlM  (init := #[]) fun acc struct => do
+        return acc ++ (← buildStructureProjEqns struct sorry)
+
+mutual
+/--
+We only  get the structure projcetions
+-/
+private partial def getStructuresFromConstantInfo (info : ConstantInfo) : MetaM (Array Name) :=
+  match info with
+  | .inductInfo val => do
+           match getStructureInfo? (← getEnv) val.name with
+             | none => pure #[]
+             | some structInfo => return #[structInfo.structName]
+  | .defnInfo val => getStructureNames val.value
+  | .thmInfo val => getStructureNames val.value
+  | .ctorInfo val => getStructureNames (mkConst val.name)
+  | .recInfo val => val.all.foldlM (init := #[])
+    fun structs nm => do
+      let newStructs ← getStructureNames (mkConst nm)
+      return structs ++ newStructs
+  | .quotInfo _ => pure #[]
+  | .opaqueInfo _ =>  pure #[]
+  | .axiomInfo _ => pure #[]
+
+private partial def getStructureNames (e : Expr) : MetaM (Array Name) := do
+
+  let env ← getEnv
+  let rec visit (e : Expr) (currNames : Array Name) : MetaM (Array Name) := do
+    match e with
+    | Expr.const name _ =>
+      match env.find? name with
+        | some info  => do
+          let newNames ← getStructuresFromConstantInfo info
+          return currNames ++ newNames
+        | none => pure currNames
+    | Expr.app fn arg =>
+      let fnNames ← visit fn currNames
+      let argNames ← visit arg currNames
+      return fnNames ++ argNames
+    | Expr.lam _ _ body _ =>
+      visit body currNames
+    | Expr.forallE _ _ body _ =>
+      visit body currNames
+    | Expr.mdata _ b =>
+      visit b currNames
+    | Expr.letE _ _ val body _ =>
+      let valNames ← visit val currNames
+      let bodyNames ← visit body currNames
+      return valNames ++ bodyNames
+    | _ => pure currNames
+  visit e #[]
+end  --mutual
+
+theorem foo : 1 + 1 = 2 := rfl
+
+#eval show MetaM Unit from do
+  let names ← getStructureNames (mkConst `foo)
+  trace[Meta.debug] s!"Structure names: {names}"

--- a/Lean/Egg/Core/Gen/StructureProjs.lean
+++ b/Lean/Egg/Core/Gen/StructureProjs.lean
@@ -77,7 +77,7 @@ private def getStructureFromConstantInfo (info : ConstantInfo) : MetaM (Option N
              | none => pure none
              | some structInfo => pure structInfo.structName
   | .ctorInfo val => do
-           match getStructureInfo? (← getEnv) val.name with
+           match getStructureInfo? (← getEnv) val.induct with
              | none => pure none
              | some structInfo => pure structInfo.structName
   | _ => pure none
@@ -127,35 +127,3 @@ theorem foo : (1,2).snd = 1 + 1 := rfl
   let constinfo ← getConstInfo `foo
   let names ← getStructureNames constinfo.value!
   logInfo s!"Structure names of {constinfo.value!}: {names}"
-
-set_option pp.raw true in
-#reduce (1,2)
-
-def pair : Prod Nat Nat := (1,2)
-
-instance : ToString ConstantInfo := ⟨fun cinfo => match cinfo with
- | .axiomInfo  val => "Axiom: {val}"
- | .defnInfo   val => "Defn: {val}"
- | .thmInfo    val => "Thm: {val}"
- | .opaqueInfo val => "Opaque: {val}"
- | .quotInfo   val => "Quot: {val}"
- | .inductInfo val => "Induct: {val}"
- | .ctorInfo   val => "Ctor: {val}"
- | .recInfo    val => "Rec: {val}"
- ⟩
-
-#eval show MetaM Unit from do
-  let constinfo ← getConstInfo `pair
-  match constinfo.value! with
-    | Expr.app (Expr.app (Expr.app (Expr.app fn arg₁) arg₂) arg₃) arg₄ => do
-       logInfo s!"Function: {fn}"
-       logInfo s!"Arg: {arg₁}"
-       logInfo s!"Arg: {arg₂}"
-       logInfo s!"Arg: {arg₃}"
-       logInfo s!"Arg: {arg₄}"
-       let some (nm, _) := fn.const?
-         | throwError "Expected constant"
-       let constInfo ← getConstInfo nm
-       logInfo s!"Constant info: {constInfo}"
-       logInfo s!"structureFromConstantInfo {← getStructureFromConstantInfo constInfo}"
-    | _ => pure ()

--- a/Lean/Egg/Core/Gen/StructureProjs.lean
+++ b/Lean/Egg/Core/Gen/StructureProjs.lean
@@ -1,0 +1,32 @@
+import Lean
+open Lean Syntax
+
+syntax (name := projfns) "#projfns " ident : command
+
+private def printStructId (id : Syntax) : Elab.Command.CommandElabM Unit := do --Elab.Command.CommandElabM Unit := do
+    let structName := id.getId
+    let env ← getEnv
+    match env.find? structName with
+    | none => throwError s!"Structure {structName} not found"
+    | some constInfo =>
+      match constInfo with
+        | .inductInfo _ => do
+           match getStructureInfo? env structName with
+             | none => throwError s!"{structName} is inductive but not a structure"
+             | some structInfo => do
+               let ctorVal := getStructureCtor env structName
+               logInfo s!"Constructor: {ctorVal.name}"
+               for fieldInfo in structInfo.fieldInfo do
+                 logInfo s!"Field {fieldInfo.fieldName}: {fieldInfo.projFn}"
+        | _ => throwError s!"{structName} is not a structure"
+
+@[command_elab projfns]
+def elabProjFns : Elab.Command.CommandElab
+  | `(#projfns%$tk  $id:ident) => withRef tk <| printStructId id
+  | _                       => throwError "invalid #print command"
+
+structure Point where
+  x : Nat
+  y : Nat
+
+#projfns Point

--- a/Lean/Egg/Core/Premise/Rewrites.lean
+++ b/Lean/Egg/Core/Premise/Rewrites.lean
@@ -139,6 +139,22 @@ where
       conds := conds.push { kind, expr := arg, type := ty, mvars }
     return conds
 
+/--
+This constructor builds a rewrite coming from an equality that is
+definitionally true.
+
+TODO: This should have a special kind that does not record a proof
+(since it needs no reconstruction).
+-/
+def mkDefEq (lhs rhs : Expr) (cfg : Config) : MetaM Rewrite := do
+  if (← isDefEq lhs rhs) then
+    let mvars : Rewrite.MVars :=
+      { lhs := ← MVars.collect lhs cfg.amb,
+        rhs := ← MVars.collect rhs cfg.amb}
+    return { rel := .eq, lhs, rhs, proof := ← mkEqRefl rhs,
+             src := .defEq lhs rhs, conds := #[], mvars}
+    else throwError m!"Error registering defEq rewrite {lhs} and {rhs} are not definitionally equal"
+
 -- Returns `none` if the given type is already ground.
 def mkGroundEq? (proof type : Expr) (src : Source) (cfg : Config) (normalize := true) :
     MetaM (Option Rewrite) := do

--- a/Lean/Egg/Core/Source.lean
+++ b/Lean/Egg/Core/Source.lean
@@ -64,6 +64,7 @@ inductive Source where
   | tcProj (src : Source) (loc : Source.TcProjLocation) (pos : SubExpr.Pos) (depth : Nat)
   | tcSpec (src : Source) (spec : Source.TcSpec)
   | nestedSplit (src : Source) (dir : Direction)
+  | defEq (lhs rhs : Expr)
   | explosion (src : Source) (dir : Direction) (loc : List Nat)
   | natLit (src : Source.NatLit)
   | subst (src : Source.SubstShift)
@@ -138,6 +139,7 @@ def description : Source → String
   | natLit src              => src.description
   | subst src               => s!"↦{src.description}"
   | shift src               => s!"↑{src.description}"
+  | defEq _ _               => "≡≡"
   | eta false               => "≡η"
   | eta true                => "≡η+"
   | beta                    => "≡β"

--- a/Lean/Egg/Tactic/Premises/Gen/Derived.lean
+++ b/Lean/Egg/Tactic/Premises/Gen/Derived.lean
@@ -3,6 +3,7 @@ import Egg.Core.Gen.TcSpecs
 import Egg.Core.Gen.GoalTcSpecs
 import Egg.Core.Gen.Explosion
 import Egg.Core.Gen.NestedSplits
+import Egg.Core.Gen.StructureProjs
 import Lean
 
 open Lean hiding HashSet
@@ -144,4 +145,4 @@ where
       setTcProjCover cover
       return rws
     generate cfg .structureProj do
-      genStructureProjections (← todo .structureProj) cfg.toDefEq
+      genStructureProjections (← todo .structureProj) goal {cfg with amb}

--- a/Lean/Egg/Tests/WIP Projections.lean
+++ b/Lean/Egg/Tests/WIP Projections.lean
@@ -7,9 +7,11 @@ example (x1 x2 : α) : x1 = (x1,x2).1 := by rfl
 
 example (x1 x2 : α) : x1 = (x1,x2).1 := by egg
 
-
 set_option trace.egg true in
 example (x1 x2 : α) : x1 = Prod.fst (Prod.mk x1 x2) := by egg
+
+set_option pp.raw true in
+#eval (1,2)
 
 #reduce  Prod.fst (Prod.mk ?Prod.fst ?Prod.snd)
 
@@ -42,3 +44,6 @@ structure Foo where
   y : Nat
 
 example (m n : Nat) : { x := m, y := n : Foo}.x = m := by egg
+
+set_option pp.raw true
+#eval (1,2)

--- a/Lean/Egg/Tests/WIP Projections.lean
+++ b/Lean/Egg/Tests/WIP Projections.lean
@@ -1,0 +1,28 @@
+import Egg
+
+-- works
+example T x1 x2 : @Eq T x1 (@Prod.mk T T x1 x2).1 := by rfl
+
+example (x1 x2 : α) : x1 = (x1,x2).1 := by rfl
+
+example (x1 x2 : α) : x1 = (x1,x2).1 := by egg
+
+example (x1 x2 : α) : x1 = Prod.fst (Prod.mk x1 x2) := by egg
+
+example T x1 x2 : @Eq T x1 (@Prod.mk T T x1 x2).1 := by rfl
+
+-- fails
+example T x1 x2 val isLt :
+  @Eq T
+    (@List.get T x1
+      (@Fin.mk (@List.length T x1) val
+        isLt))
+    (@List.get T x1
+      (@Fin.mk (@List.length T (@Prod.mk (List T) (List T) x1 x2).1) val
+         isLt)) := by egg
+
+structure Foo where
+  x : Nat
+  y : Nat
+
+example (m n : Nat) : { x := m, y := n : Foo}.x = m := by egg

--- a/Lean/Egg/Tests/WIP Projections.lean
+++ b/Lean/Egg/Tests/WIP Projections.lean
@@ -7,7 +7,23 @@ example (x1 x2 : α) : x1 = (x1,x2).1 := by rfl
 
 example (x1 x2 : α) : x1 = (x1,x2).1 := by egg
 
+
+set_option trace.egg true in
 example (x1 x2 : α) : x1 = Prod.fst (Prod.mk x1 x2) := by egg
+
+#reduce  Prod.fst (Prod.mk ?Prod.fst ?Prod.snd)
+
+open Lean in
+#eval show MetaM Unit from do
+  let α ← mkFreshLMVarId
+  let β ← mkFreshLMVarId
+  let x ← mkFreshLMVarId
+  let y ← mkFreshLMVarId
+  let lhs ← mkAppN (mkConst `Prod.fst) #[mkAppN `Prod.mk #[mkMVar x, mkMVar y]]
+  let rhs ← getConstInfo `rhs
+  Lean.logInfo s!"{lhs.value!}"
+  Lean.logInfo s!"{(← Lean.Meta.isDefEq lhs.value! rhs.value!)}"
+
 
 example T x1 x2 : @Eq T x1 (@Prod.mk T T x1 x2).1 := by rfl
 


### PR DESCRIPTION
This adds rewrites to deal with structure projections, of the form: `StructureName.field1 StructureName.mk ?a ?b ... = ?a` and so forth