### PR TITLE
Proof irrelevance type level rewrites

### DIFF
--- a/Lean/Egg/Core/Direction.lean
+++ b/Lean/Egg/Core/Direction.lean
@@ -6,7 +6,7 @@ namespace Egg
 inductive Direction where
   | forward
   | backward
-deriving Inhabited, BEq, Hashable, Ord
+deriving Inhabited, BEq, Hashable, Ord, Repr
 
 namespace Direction
 

--- a/Lean/Egg/Core/Explanation/Basic.lean
+++ b/Lean/Egg/Core/Explanation/Basic.lean
@@ -21,11 +21,11 @@ structure Descriptor where
   id       : Rewrite.Rule.Id
   dir      : Direction
   weakVars : Array (Nat × Nat)
-deriving Inhabited
+deriving Inhabited, Repr
 
 structure Info extends Descriptor where
   pos? : Option SubExpr.Pos
-deriving Inhabited
+deriving Inhabited, Repr
 
 end Rewrite
 

--- a/Lean/Egg/Core/Explanation/Parse/Egg.lean
+++ b/Lean/Egg/Core/Explanation/Parse/Egg.lean
@@ -171,7 +171,8 @@ where
     let rwIsOutsideType := (← get).isSome
     let e ← go pos t
     if let some rwInfo ← get then
-      unless rwIsOutsideType || rwInfo.id.src.isDefEq do throw .nonDefeqTypeRw
+      unless rwIsOutsideType || rwInfo.id.src.isDefEq do
+        throw .nonDefeqTypeRw
     return e
 
   parseRw (dir : TSyntax `rw_dir) (src : TSyntax `rw_src) (body : TSyntax `egg_expr)

--- a/Lean/Egg/Core/Explanation/Parse/Egg.lean
+++ b/Lean/Egg/Core/Explanation/Parse/Egg.lean
@@ -20,7 +20,24 @@ private inductive Expression where
   | subst  (idx : Nat) (to e : Expression)
   | shift  (offset : Int) (cutoff : Nat) (e : Expression)
   | unknown
-deriving Inhabited
+deriving Inhabited, Repr
+
+private def Expression.pp (levels := false) :  Expression → String
+  | bvar idx => toString idx
+  | fvar id => toString id.name
+  | mvar id => s!"?{toString id.name}"
+  | sort lvl => if levels then s!"Sort.\{{toString lvl}}" else "Sort"
+  | const name lvls => if levels then s!"{name}\{{",".intercalate <| lvls.map toString}}" else toString name
+  | app fn arg => s!"({Expression.pp (levels:=levels) fn} {Expression.pp (levels:=levels) arg})"
+  | lam _ body => s!"(λ.{Expression.pp (levels:=levels) body})"
+  | «forall»  _ body => s!"(λ.{Expression.pp (levels:=levels) body})"
+  | lit l => s!"{repr l}"
+  | eq lhs rhs => s!"{Expression.pp (levels:=levels) lhs} = {Expression.pp (levels:=levels) rhs}"
+  | proof _ => "⋯"
+  | inst cls => s!"inst{Expression.pp (levels:=levels) cls}"
+  | subst idx to e => s!"(subst {idx} {Expression.pp (levels:=levels) to} {Expression.pp (levels:=levels) e})"
+  | shift offset cutoff e => s!"(shift {offset} {cutoff} {Expression.pp (levels:=levels) e}"
+  | unknown => "???"
 
 -- If `synthesize` is true, we try to fill type class instance holes immediately by synthesis.
 private def Expression.toExpr (e : Expression) (synthesize := false) : MetaM Expr := do

--- a/Lean/Egg/Core/Rewrite/Rule.lean
+++ b/Lean/Egg/Core/Rewrite/Rule.lean
@@ -7,7 +7,7 @@ namespace Egg.Rewrite
 structure Rule.Id where
   src : Source
   dir : Direction
-deriving Inhabited, BEq, Hashable, Ord
+deriving Inhabited, BEq, Hashable, Ord, Repr
 
 -- TODO: We are currently ordering `Source`s by their string description. Other orderings (e.g. by
 --       category may be nicer for tracing).

--- a/Lean/Egg/Core/Source.lean
+++ b/Lean/Egg/Core/Source.lean
@@ -142,8 +142,9 @@ instance : Ord Source where
   compare src₁ src₂ := compare src₁.description src₂.description
 
 def isDefEq : Source → Bool
-  | natLit _ | eta _ | beta | level _ | subst _ | shift _ | structProj _ => true
-  | _                                                                    => false
+  | natLit _ | eta _ | beta | level _ | subst _ | shift _ | structProj _
+  | tcProj _ _ _ _ => true
+  | _              => false
 
 def containsTcProj : Source → Bool
   | tcProj ..                                          => true

--- a/Lean/Egg/Core/Source.lean
+++ b/Lean/Egg/Core/Source.lean
@@ -15,21 +15,21 @@ inductive Source.NatLit where
   | pow
   | div
   | mod
-deriving Inhabited, BEq, Hashable
+deriving Inhabited, BEq, Hashable, Repr
 
 inductive Source.Level where
   | maxSucc
   | maxComm
   | imaxZero
   | imaxSucc
-deriving Inhabited, BEq, Hashable
+deriving Inhabited, BEq, Hashable, Repr
 
 inductive Source.TcProjLocation where
   | root
   | left
   | right
   | cond (idx : Nat)
-deriving Inhabited, BEq, Hashable
+deriving Inhabited, BEq, Hashable, Repr
 
 inductive Source.SubstShift where
   | bvar
@@ -44,7 +44,7 @@ inductive Source.SubstShift where
   | inst
   | unknown
   | abort
-deriving Inhabited, BEq, Hashable
+deriving Inhabited, BEq, Hashable, Repr
 
 inductive Source where
   | goal
@@ -67,7 +67,7 @@ inductive Source where
   | level (src : Source.Level)
   | builtin (idx : Nat)
   | tagged (name : Name) (eqn? : Option Nat)
-deriving Inhabited, BEq, Hashable
+deriving Inhabited, BEq, Hashable, Repr
 
 namespace Source
 

--- a/Lean/Egg/Tests/Proof Irrelevance.lean
+++ b/Lean/Egg/Tests/Proof Irrelevance.lean
@@ -1,0 +1,12 @@
+import Egg
+
+
+example : @Eq (Fin 3) ⟨1, Nat.one_lt_succ_succ 1⟩ ⟨1, by omega⟩ := by
+  rfl
+
+example : @Eq (Fin 3) ⟨1, Nat.one_lt_succ_succ 1⟩ ⟨1, by omega⟩ := by
+  egg
+
+example  (l l' : List Nat) (a : Nat) :
+       (a :: (l ++ l')).getLast (List.cons_ne_nil a _) =  ((a :: l) ++ l').getLast (List.cons_ne_nil a _) :=
+         by egg [List.append]


### PR DESCRIPTION
typeclass projections should be defeq too, this fixes issues where some proof-level rewrites would make a defeq rewrite fail to reconstruct.

(checking here to see if nothing broke with this, i.e. if CI works for the rest)